### PR TITLE
Accept extra values for boolean environment variables

### DIFF
--- a/src/typenv/__init__.py
+++ b/src/typenv/__init__.py
@@ -55,9 +55,10 @@ class ParsedValue(NamedTuple):
 
 
 def _cast_bool(value: str) -> bool:
-    if value.lower() == "true":
+    value = value.lower()
+    if value in ("y", "yes", "t", "true", "on", "1"):
         return True
-    if value.lower() == "false":
+    if value in ("n", "no", "f", "false", "off", "0"):
         return False
     raise Exception(f'Failed to cast value "{value}" to bool')
 


### PR DESCRIPTION
The values match the ones accepted both by [marshmallow](https://github.com/marshmallow-code/marshmallow/blob/126fca52f88a19601159940d977bfdfa9e70bcbb/src/marshmallow/fields.py#L1131-L1169) and the [strtobool utility function in the distutil module](https://github.com/python/cpython/blob/ff54dd96cbe589635ed95c8b5b26bc768166b07d/Lib/distutils/util.py#L308-L321).